### PR TITLE
Adding options to configure the theme easily for our purposes

### DIFF
--- a/demo/source/conf.py
+++ b/demo/source/conf.py
@@ -30,8 +30,7 @@ release = '0.0.1'
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
-extensions = [
-]
+extensions = []
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']
@@ -49,11 +48,19 @@ exclude_patterns = []
 #
 html_theme = 'sphinx_pythia_theme'
 html_theme_options = {
-    'banner_bgimage': '_static/background.jpg',
-    'banner_mask_color': 'rgb(0,100,0)',
-    'banner_mask_opacity': '0.6',
+    # 'onepagenames': ['index'],
+    # 'navbar_title': '',
+    # 'navbar_fixed_top': True,
+    'navbar_links': {
+        'The Book': 'chapter1',
+        'GitHub': 'https://github.com/ProjectPythia/sphinx-pythia-theme',
+    },
+    # 'banner_bgimage': '_static/background.jpg',
+    # 'banner_mask_color': 'rgb(0,100,0)',
+    # 'banner_mask_opacity': '0.6',
     'sponsor_text': 'This material is based upon work supported by the National Science Foundation under Grant No. ABCDEFG.  Any opinions, findings, and conclusions or recommendations expressed in this material are those of the author(s) and do not necessarily reflect the views of the National Science Foundation.',
     'sponsor_image': '_static/sponsor.png',
+    # 'permalinks_icon': 'bi bi-link',
 }
 
 # Add any paths that contain custom static files (such as style sheets) here,
@@ -61,5 +68,6 @@ html_theme_options = {
 # so a file named "default.css" will overwrite the builtin "default.css".
 html_static_path = ['_static']
 
+# Custom logo and favicon
 html_logo = '_static/logo.svg'
 html_favicon = '_static/favicon.ico'

--- a/demo/source/conf.py
+++ b/demo/source/conf.py
@@ -50,7 +50,6 @@ html_theme = 'sphinx_pythia_theme'
 html_theme_options = {
     # 'onepagenames': ['index'],
     # 'navbar_title': '',
-    # 'navbar_fixed_top': True,
     'navbar_links': {
         'The Book': 'chapter1',
         'GitHub': 'https://github.com/ProjectPythia/sphinx-pythia-theme',

--- a/demo/source/index.rst
+++ b/demo/source/index.rst
@@ -1,5 +1,5 @@
-Project Pythia
-==============
+Banner
+======
 
 Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor
 incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud
@@ -8,8 +8,8 @@ irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nul
 pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia
 deserunt mollit anim id est laborum.
 
-Section 1
----------
+Card 1
+------
 
 Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor
 incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud
@@ -18,8 +18,8 @@ irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nul
 pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia
 deserunt mollit anim id est laborum.
 
-Section 2
----------
+Card 2
+------
 
 Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor
 incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud
@@ -28,8 +28,8 @@ irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nul
 pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia
 deserunt mollit anim id est laborum.
 
-Section 2.1
-~~~~~~~~~~~
+Subcard
+~~~~~~~
 
 Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor
 incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud
@@ -38,8 +38,8 @@ irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nul
 pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia
 deserunt mollit anim id est laborum.
 
-Section 3
----------
+Card 3
+------
 
 Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor
 incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud
@@ -48,8 +48,8 @@ irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nul
 pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia
 deserunt mollit anim id est laborum.
 
-Section 4
----------
+Card 4
+------
 
 Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor
 incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud

--- a/sphinx_pythia_theme/__init__.py
+++ b/sphinx_pythia_theme/__init__.py
@@ -140,9 +140,10 @@ def add_functions_to_context(app, pagename, templatename, context, doctree):
 
 def set_default_permalinks_icon(app):
     if 'permalinks_icon' in app.config.html_theme_options:
-        app.config.html_permalinks_icon = app.config.html_theme_options['permalinks_icon']
+        icon_class = app.config.html_theme_options['permalinks_icon']
     else:
-        app.config.html_permalinks_icon = '<i class="bi bi-link"></i>'
+        icon_class = 'bi bi-link'
+    app.config.html_permalinks_icon = f'<i class="{icon_class}"></i>'
 
 
 def setup(app: Sphinx):

--- a/sphinx_pythia_theme/layout.html
+++ b/sphinx_pythia_theme/layout.html
@@ -31,19 +31,19 @@
 {%- block content %}
     {{- pythiaNavbar() }}
 
-    {%- if pagename == 'index' %}
+    {%- if pagename in theme_onepagenames %}
     <div class="container-fluid wrapper onecolumn">
     {%- else %}
     <div class="container-fluid wrapper twocolumn">
     {%- endif %}
 
-      {%- if pagename != 'index' %}
+      {%- if pagename not in theme_onepagenames %}
       {%- block sidebar1 %}{{ pythiaSidebar() }}{% endblock %}
       {%- endif %}
 
       <!-- Main -->
       <main role="main" id="main">
-        {%- if pagename == 'index' %}
+        {%- if pagename in theme_onepagenames %}
         {%- include "onepage.html" %}
         {%- else %}
         {%- block body %}{% endblock %}

--- a/sphinx_pythia_theme/navbar.html
+++ b/sphinx_pythia_theme/navbar.html
@@ -1,4 +1,3 @@
-    {% set nav_items = get_nav_items() %}
     <!-- Navbar (Top)-->
     <nav class="navbar navbar-expand-lg {% if theme_navbar_fixed_top|tobool -%} fixed-top {%- endif %} navbar-dark bg-dark shadow">
       <div class="container-fluid">
@@ -11,13 +10,16 @@
         </button>
         <div class="collapse navbar-collapse" id="navbarNavDropdown">
           <ul class="navbar-nav">
-            {%- for item in nav_items %}
-            {{ item }}
-            {%- endfor -%}
-            {% if theme_navbar_links %}
+            {%- if theme_navbar_links %}
             {%- for link in theme_navbar_links %}
-            <li class="nav-item">
-              <a class="nav-link" href="{{ pathto(*link[1:]) }}">{{ link[0] }}</a>
+            {%- set link_ref = theme_navbar_links[link] %}
+            {%- if hasdoc(link_ref) %}
+            {%- set link_href = pathto(link_ref) %}
+            {%- else %}
+            {%- set link_href = link_ref %}
+            {%- endif %}
+          <li class="nav-item">
+              <a class="nav-link" href="{{ link_href }}">{{ link }}</a>
             </li>
             {%- endfor %}
             {% endif %}

--- a/sphinx_pythia_theme/navbar.html
+++ b/sphinx_pythia_theme/navbar.html
@@ -1,5 +1,5 @@
     <!-- Navbar (Top)-->
-    <nav class="navbar navbar-expand-lg {% if theme_navbar_fixed_top|tobool -%} fixed-top {%- endif %} navbar-dark bg-dark shadow">
+    <nav class="navbar navbar-expand-lg fixed-top navbar-dark bg-dark shadow">
       <div class="container-fluid">
         <a class="navbar-brand" href="{{ pathto(master_doc) }}">
           {%- if logo %}<img src="{{ pathto('_static/' + logo, 1) }}">{%- endif -%}
@@ -13,12 +13,13 @@
             {%- if theme_navbar_links %}
             {%- for link in theme_navbar_links %}
             {%- set link_ref = theme_navbar_links[link] %}
+            {%- set active = '' %}
             {%- if hasdoc(link_ref) %}
             {%- set link_href = pathto(link_ref) %}
             {%- else %}
             {%- set link_href = link_ref %}
             {%- endif %}
-          <li class="nav-item">
+            <li class="nav-item">
               <a class="nav-link" href="{{ link_href }}">{{ link }}</a>
             </li>
             {%- endfor %}

--- a/sphinx_pythia_theme/theme.conf
+++ b/sphinx_pythia_theme/theme.conf
@@ -5,12 +5,13 @@ pygments_style = friendly
 sidebars =
 
 [options]
-use_page_nav =
+onepagenames = index
 navbar_title =
 navbar_fixed_top = true
+navbar_links =
 banner_bgimage =
 banner_mask_color =
 banner_mask_opacity =
 sponsor_text =
 sponsor_image =
-permalinks_icon =
+permalinks_icon = bi bi-link

--- a/sphinx_pythia_theme/theme.conf
+++ b/sphinx_pythia_theme/theme.conf
@@ -7,7 +7,6 @@ sidebars =
 [options]
 onepagenames = index
 navbar_title =
-navbar_fixed_top = true
 navbar_links =
 banner_bgimage =
 banner_mask_color =


### PR DESCRIPTION
This verifies and adds the following options to the theme:

- `onepagenames`: This is a list of pagenames for pages on the Sphinx site that should be rendered with the "One Pager" layout.  This defaults to `index`.
- `navbar_title`: This is a string that will be used on the far-left of the top navbar.  It is not desireable to use this with a logo (which is also placed on the far-left of the top navbar).
- `navbar_links`: This is an ordered dictionary of names and corresponding pagenames/URLs that will be used to populate the top navbar.
- `banner_bgimage`: This is a background image to be used in the "Banner" sections (H1 sections) of the "One Pager" pages.
- `banner_mask_color`: This is the "mask" color to be used over top of the `banner_image` to give it a strong color (e.g., blue).
- `banner_mask_opacity`: This is the opacity of the Banner "mask".  If the opacity is 1, then the Banner background images will be hidden.
- `sponsor_text`: This is the text needed for the "sponsor" section at the bottom of the footer.
- `sponsor_image`: This is the image file to be used with the sponsor text.
- `permalinks_icon`: This is the permalink icon CSS class to be used for permalinks.  Permalink icons are the icons that are usually hidden (except when hovering) next to page section titles, and they can be selected to copy the "permalink URL" to that section in the document.  (The default permalink icon by Sphinx is the paragraph symbol, but this theme uses the Bootstrap Icon `bi bi-link` class by default, instead.)

More to come