### PR TITLE
Set height to auto after transition

### DIFF
--- a/sphinx_pythia_theme/static/js/pythia.js
+++ b/sphinx_pythia_theme/static/js/pythia.js
@@ -82,7 +82,7 @@ function expandSidebar() {
     sidebarNav.style.height = sidebarNavHeight + 'px';
     sidebarNav.addEventListener('transitionend', function(e) {
         sidebarNav.removeEventListener('transitionend', arguments.callee);
-        sidebarNav.style.height = null;
+        sidebarNav.style.height = 'auto';
     });
 
     document.getElementById('contractIcon').classList.remove('bi-chevron-expand');


### PR DESCRIPTION
Fixes #9 

This explicitly sets the height of the sidebar to `auto` after each expand/contract transition (instead of `null`, which it was previously set to).  Seems to fix the sidebar height resetting bug.