### PR TITLE
Fixing domnav linking

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -120,7 +120,7 @@ html_theme_options = {
     "logo_only": True,
     "show_toc_level": 2,
     "domnav": [
-        {"content": "Documentation", "url": "/this-theme"},
+        {"content": "Documentation", "url": "this-theme"},
         {
             "content": "GitHub",
             "url": "https://github.com/ProjectPythia/sphinx-pythia-theme",

--- a/sphinx_pythia_theme/__init__.py
+++ b/sphinx_pythia_theme/__init__.py
@@ -7,7 +7,7 @@ from sphinx.application import Sphinx
 
 from .banner import Banner
 
-__version__ = "2021.12.1"
+__version__ = "2021.12.2"
 
 
 def get_html_theme_path():

--- a/sphinx_pythia_theme/header.html
+++ b/sphinx_pythia_theme/header.html
@@ -10,8 +10,13 @@
       <ul class="navbar-nav">
         {% if theme_domnav %}
         {% for link in theme_domnav %}
+        {% if hasdoc(link['url']) %}
+        {% set href = pathto(link['url']) %}
+        {% else %}
+        {% set href = link['url'] %}
+        {% endif %}
         <li class="nav-item">
-          <a class="nav-link" href={{ link['url'] }}>{{ link['content'] }}</a>
+          <a class="nav-link" href="{{ href }}">{{ link['content'] }}</a>
         </li>
         {% endfor %}
         {% endif %}


### PR DESCRIPTION
Previously, the domain navigation bar at the top required that the URL links provided for the domain navigation links be fully resolved, valid URLs.  This meant that the user could not specify a Sphinx [document name](https://www.sphinx-doc.org/en/master/usage/configuration.html#:~:text=Remember%20that%20document%20names%20use%20/%20as%20the%20path%20separator%20and%20don%E2%80%99t%20contain%20the%20file%20name%20extension.) and expect the builder to make the link valid (i.e., pointing to a valid HTML file).  This PR fixes this, and it should fix the linking problem in the ReadTheDocs pages.