### PR TITLE
Fixes for links and documentation

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -55,13 +55,6 @@ sphinx:
       github_url: https://github.com/ProjectPythia/sphinx-pythia-theme
       twitter_url: https://twitter.com/project_pythia
       repository_url: https://github.com/ProjectPythia/sphinx-pythia-theme
-      extra_footer: |
-        <img src="/_static/nsf-logo.png" style="float:left;width:60px;height:60px;margin-right:1rem;">
-        This material is based upon work supported by the National
-        Science Foundation under Grant Nos. 2026863 and 2026899. Any
-        opinions, findings, and conclusions or recommendations expressed
-        in this material are those of the author(s) and do not necessarily
-        reflect the views of the National Science Foundation.
       extra_navbar: Theme by <a href="https://projectpythia.org">Project Pythia</a>
       navbar_links:
         - name: Documentation

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -3,6 +3,7 @@
 title: ""
 logo: images/dummy_logo_dark.svg
 author: the Project Pythia Community
+copyright: "2022"
 email: kpaul@ucar.edu
 description: >- # this means to ignore newlines
   This is an example book built with Jupyter Books.

--- a/docs/_templates/footer-extra.html
+++ b/docs/_templates/footer-extra.html
@@ -1,0 +1,19 @@
+  <div class="container-fluid footer-extra">
+    <div class="container">
+      <div class="row">
+        {%- if theme_extra_footer %}
+        <p class="m-0 mb-2">
+          {{ theme_extra_footer }}
+        </p>
+        {%- endif %}
+        <p class="m-0">
+          <img src="{{ pathto('_static/nsf-logo.png', 1) }}" style="float:left;width:60px;height:60px;margin-right:1rem;">
+          This material is based upon work supported by the National
+          Science Foundation under Grant Nos. 2026863 and 2026899. Any
+          opinions, findings, and conclusions or recommendations expressed
+          in this material are those of the author(s) and do not necessarily
+          reflect the views of the National Science Foundation.
+        </p>
+      </div>
+    </div>
+  </div>

--- a/docs/about.rst
+++ b/docs/about.rst
@@ -296,8 +296,6 @@ to use for the given document name.  By default, any pages not listed in the
 ``page_layouts`` option will have the default page layout, which corresponds to
 the typical layout of any Jupyter Book page.
 
-The `landing page <index.html>`_ of this documentation is an example of this layout.
-
 Standalone Pages
 ^^^^^^^^^^^^^^^^
 
@@ -305,7 +303,7 @@ Standalone pages use the ``page-standalone.html`` template in the same way that 
 *banner* pages above use the ``page-banner.html`` template.  Standalone pages have
 the same heading and text styling used by banner pages, but they do not have extra
 padding nor the ability to declare banner backgrounds to the sections.  The
-`Standalone <standalone.html>`_ page is an example of this layout.
+:doc:`/standalone` page is an example of this layout.
 
 Custom Templates
 ----------------

--- a/docs/about.rst
+++ b/docs/about.rst
@@ -61,10 +61,10 @@ will be displayed after any links specified by the ``navbar_links`` option.
               - content: Link2
                 url: https://link2.com/some/other/link
 
-:::{note}
-The ``url`` value can be a Sphinx document name, in addition to an absolute or relative URL.  In fact,
-using Sphinx document names is the best way of generating the link correctly on different pages.
-:::
+.. note::
+
+   The ``url`` value can be a Sphinx document name, in addition to an absolute or relative URL.  In fact,
+   using Sphinx document names is the best way of generating the link correctly on different pages.
 
 Icons can be displayed in the top right of the navigation bar using the PyData Sphinx Theme's
 `icon links customization <https://pydata-sphinx-theme.readthedocs.io/en/latest/user_guide/configuring.html#local-image-icons>`_

--- a/docs/about.rst
+++ b/docs/about.rst
@@ -61,6 +61,11 @@ will be displayed after any links specified by the ``navbar_links`` option.
               - content: Link2
                 url: https://link2.com/some/other/link
 
+:::{note}
+The ``url`` value can be a Sphinx document name, in addition to an absolute or relative URL.  In fact,
+using Sphinx document names is the best way of generating the link correctly on different pages.
+:::
+
 Icons can be displayed in the top right of the navigation bar using the PyData Sphinx Theme's
 `icon links customization <https://pydata-sphinx-theme.readthedocs.io/en/latest/user_guide/configuring.html#local-image-icons>`_
 (``icon_links``) option or by using the built-in PyData Sphinx Theme

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -148,7 +148,7 @@ html_theme_options = {
     "show_toc_level": 2,
     "navbar_align": "left",
     "navbar_links": [
-        {"name": "Documentation", "url": "index.html#documentation"},
+        {"name": "Documentation", "url": "index#documentation"},
     ],
     "external_links": [
         {

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -10,7 +10,7 @@ import sys
 # -- Project information -----------------------------------------------------
 
 author = "the Project Pythia Community"
-copyright = "2021"
+copyright = "2022"
 
 # -- General configuration ---------------------------------------------------
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -148,7 +148,7 @@ html_theme_options = {
     "show_toc_level": 2,
     "navbar_align": "left",
     "navbar_links": [
-        {"name": "Documentation", "url": "/index.html#documentation"},
+        {"name": "Documentation", "url": "index.html#documentation"},
     ],
     "external_links": [
         {
@@ -165,14 +165,6 @@ html_theme_options = {
         "Unidata": "images/Unidata_logo_horizontal_1200x300.svg",
         "UAlbany": "images/UAlbany-A2-logo-purple-gold.svg",
     },
-    "extra_footer": (
-        '<img src="/_static/nsf-logo.png" style="float:left;width:60px;height:60px;margin-right:1rem;">'
-        "This material is based upon work supported by the National "
-        "Science Foundation under Grant Nos. 2026863 and 2026899. Any "
-        "opinions, findings, and conclusions or recommendations expressed "
-        "in this material are those of the author(s) and do not necessarily "
-        "reflect the views of the National Science Foundation."
-    ),
     "extra_navbar": ('Theme by <a href="https://projectpythia.org">Project Pythia</a>'),
 }
 

--- a/docs/getreferences.py
+++ b/docs/getreferences.py
@@ -6,7 +6,6 @@
 
 import os
 from pathlib import Path
-import pprint
 
 import click
 import requests

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -17,7 +17,7 @@ Book, however, just like the Sphinx Book Theme, itself.
 .. raw:: html
 
    <span class="d-flex justify-content-center py-4">
-     <a href="/about.html" role="button" class="btn btn-light btn-lg">
+     <a href="about.html" role="button" class="btn btn-light btn-lg">
        Read more about the Sphinx Pythia Theme
      </a>
    </span>
@@ -58,7 +58,7 @@ Documentation
 .. raw:: html
 
    <span class="d-flex justify-content-center py-4">
-     <a href="/about.html" role="button" class="btn btn-primary btn-lg">
+     <a href="about.html" role="button" class="btn btn-primary btn-lg">
        Read the documentation
      </a>
    </span>

--- a/sphinx_pythia_theme/__init__.py
+++ b/sphinx_pythia_theme/__init__.py
@@ -115,6 +115,17 @@ def add_functions_to_context(app, pagename, templatename, context, doctree):
 
     context["apply_denested_layout"] = apply_denested_layout
 
+    def spt_pathto(uri):
+        baseuri, anchor = uri.split('#', 1) if '#' in uri else (uri, '')
+        anchor = '#' + anchor if anchor else ''
+        if context['hasdoc'](baseuri):
+            docuri = context['pathto'](baseuri)
+            return docuri.split('#', 1)[0] + anchor
+        else:
+            return uri
+
+    context["spt_pathto"] = spt_pathto
+
 
 def copy_image(app, image):
     conf_dir = Path(app.confdir)

--- a/sphinx_pythia_theme/footer-menu.html
+++ b/sphinx_pythia_theme/footer-menu.html
@@ -22,11 +22,11 @@
             {% set ext_icon = '' %}
             {% endif %}
             {% if item_url and item_name %}
-            <li><a href="{{ item_url }}">{{ _(item_name) }}{{ ext_icon }}</a></li>
+            <li><a href="{{ spt_pathto(item_url) }}">{{ _(item_name) }}{{ ext_icon }}</a></li>
             {% elif item_name %}
             <li>{{ item_name }}</li>
             {% elif item_url %}
-            <li><a href="{{ item_url }}">{{ item_url }}{{ ext_icon }}</a></li>
+            <li><a href="{{ spt_pathto(item_url) }}">{{ item_url }}{{ ext_icon }}</a></li>
             {% endif %}
             {% endfor %}
           </ul>

--- a/sphinx_pythia_theme/navbar-menu.html
+++ b/sphinx_pythia_theme/navbar-menu.html
@@ -2,10 +2,18 @@
   {% for navbar_link in theme_navbar_links %}
   <li class="nav-item">
     {% if "external" in navbar_link and navbar_link.external %}
-    <a class="nav-link nav-internal" href="{{ navbar_link.url }}">{{ _(navbar_link.name) }}<i class="fas fa-external-link-alt"></i></a>
+    {% set external = '<i class="fas fa-external-link-alt"></i>' %}
     {% else %}
-    <a class="nav-link nav-internal" href="{{ navbar_link.url }}">{{ _(navbar_link.name) }}</a>
+    {% set external = '' %}
     {% endif %}
+    {% set base, anchor = navbar_link.url.split('#', 1) if '#' in navbar_link.url else (navbar_link.url, '') %}
+    {% if hasdoc(base) %}
+    {% set docpath = pathto(base) %}
+    {% set url = docpath.split('#', 1)[0] + '#' + anchor %}
+    {% else %}
+    {% set url = navbar_link.url %}
+    {% endif %}
+    <a class="nav-link nav-internal" href="{{ url }}">{{ _(navbar_link.name) }}{{ external }}</a>
   </li>
   {% endfor %}
   {% for external_link in theme_external_links %}

--- a/sphinx_pythia_theme/navbar-menu.html
+++ b/sphinx_pythia_theme/navbar-menu.html
@@ -6,14 +6,7 @@
     {% else %}
     {% set external = '' %}
     {% endif %}
-    {% set base, anchor = navbar_link.url.split('#', 1) if '#' in navbar_link.url else (navbar_link.url, '') %}
-    {% if hasdoc(base) %}
-    {% set docpath = pathto(base) %}
-    {% set url = docpath.split('#', 1)[0] + '#' + anchor %}
-    {% else %}
-    {% set url = navbar_link.url %}
-    {% endif %}
-    <a class="nav-link nav-internal" href="{{ url }}">{{ _(navbar_link.name) }}{{ external }}</a>
+    <a class="nav-link nav-internal" href="{{ spt_pathto(navbar_link.url) }}">{{ _(navbar_link.name) }}{{ external }}</a>
   </li>
   {% endfor %}
   {% for external_link in theme_external_links %}


### PR DESCRIPTION
This PR fixes some incorrect links generated throughout the document and implements a more robust mechanism for getting the links correct on every page.  Use of relative URLs doesn't work when some pages are in deeper directories, and use of absolute URLs doesn't work when the web host places the HTML site in a deeper hierarchy (e.g., as readthedocs does, placing the HTML directory in a subdirectory like `/{loc}/{build}/` where `{loc}` is the locale language and `{build}` is the RTD build version).  The fix for this is to use Sphinx's builtin `pathto(docname)` function to find the path to a document with the name `docname` from the page the link is being generated on!  Thus, the actual HTML `href` for the link will be custom built for each page.  (Obviously, this requires fixing the templates to look for docnames, too!)