### PR TITLE
Fixes for wide screens / high resolution

### DIFF
--- a/sphinx_pythia_theme/docs-navbar.html
+++ b/sphinx_pythia_theme/docs-navbar.html
@@ -1,0 +1,31 @@
+<div class="container-fluid">
+
+  <div id="navbar-start">
+    {% for navbar_item in theme_navbar_start %}
+    {% include navbar_item %}
+    {% endfor %}
+  </div>
+
+  <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbar-collapsible" aria-controls="navbar-collapsible" aria-expanded="false" aria-label="{{ _('Toggle navigation') }}">
+    <span class="navbar-toggler-icon"></span>
+  </button>
+
+  {% set navbar_class, navbar_align = navbar_align_class() %}
+  <div id="navbar-collapsible" class="{{ navbar_class }} collapse navbar-collapse">
+    <div id="navbar-center" class="{{ navbar_align }}">
+      {% for navbar_item in theme_navbar_center %}
+      <div class="navbar-center-item">
+        {% include navbar_item %}
+      </div>
+      {% endfor %}
+    </div>
+
+    <div id="navbar-end">
+      {% for navbar_item in theme_navbar_end %}
+      <div class="navbar-end-item">
+        {% include navbar_item %}
+      </div>
+      {% endfor %}
+    </div>
+  </div>
+</div>

--- a/sphinx_pythia_theme/layout.html
+++ b/sphinx_pythia_theme/layout.html
@@ -5,42 +5,58 @@
 {%- endblock %}
 
 {%- block content %}
-<div class="container-fluid" id="shim"></div>
-{{ super() }}
-{%- endblock %}
+    <div class="container-fluid" id="shim"></div>
+    <div class="container-fluid" id="banner"></div>
 
-{%- block docs_sidebar %}
-{%- if sidebars %}
-{{ super() }}
-{%- endif %}
-{% endblock %}
+    {%- block docs_navbar %}
+    <nav class="navbar navbar-dark navbar-expand-lg bg-dark fixed-top bd-navbar shadow" id="navbar-main">
+      {%- include "docs-navbar.html" %}
+    </nav>
+    {%- endblock %}
 
-{%- block docs_main %}
-{%- if theme_page_layouts and pagename in theme_page_layouts %}
-{%- include theme_page_layouts[pagename] %}
-{%- else %}
-<main class="col py-md-3 pl-md-4 bd-content overflow-auto" role="main">
-  {%- block docs_body %}
-  {%- if sidebars %}
-  {%- include "topbar.html" %}
-  {%- endif %}
-  <div id="main-content" class="row">
-    <div class="col-12 col-md-9 pl-md-3 pr-md-0">
-      {{ super.super() }}
-      {% if theme_show_prev_next %}
-      {% include "_templates/prev-next.html" %}
-      {% endif %}
+    <div class="container-fluid">
+      <div class="row">
+        {%- block docs_sidebar %}
+        {%- if sidebars %}
+        {{ super() }}
+        {%- else %}
+        <div class="d-none col-12 col-md-1 col-xl-2 bd-sidebar no-sidebar"></div>
+        {%- endif %}
+        {%- endblock %}
+
+        {%- block docs_toc %}
+        {{ super() }}
+        {%- endblock %}
+
+        {%- block docs_main %}
+        {%- if theme_page_layouts and pagename in theme_page_layouts %}
+        {%- include theme_page_layouts[pagename] %}
+        {%- else %}
+        <main class="col py-md-3 pl-md-4 bd-content overflow-auto" role="main">
+          {%- block docs_body %}
+          {%- if sidebars %}
+          {%- include "topbar.html" %}
+          {%- endif %}
+          <div id="main-content" class="row">
+            <div class="col-12 col-md-9 pl-md-3 pr-md-0">
+              {{ super.super() }}
+              {%- if theme_show_prev_next %}
+              {%- include "_templates/prev-next.html" %}
+              {%- endif %}
+            </div>
+          </div>
+          {%- endblock %}
+        </main>
+        {%- endif %}
+        {%- endblock %}
+
+      </div>
     </div>
-  </div>
-  {%- endblock %}
-</main>
-{%- endif %}
-{%- endblock %}
 
-{%- block docs_navbar %}
-<nav class="navbar navbar-dark navbar-expand-lg bg-dark fixed-top bd-navbar shadow" id="navbar-main">
-  {%- include "docs-navbar.html" %}
-</nav>
+  {%- block scripts_end %}
+  {{ _webpack.body_post() }}
+  {%- endblock %}
+
 {%- endblock %}
 
 {%- block footer %}

--- a/sphinx_pythia_theme/topbar.html
+++ b/sphinx_pythia_theme/topbar.html
@@ -1,0 +1,35 @@
+<div class="topbar container-fluid fixed-top">
+  <div class="topbar-contents row">
+    <div class="col-12 col-md-3 bd-topbar-whitespace site-navigation show"></div>
+    <div class="col pl-md-4 topbar-main">
+      {% if theme_single_page != True %}
+      <button id="navbar-toggler" class="navbar-toggler ml-0" type="button" data-toggle="collapse"
+        data-toggle="tooltip" data-placement="bottom" data-target=".site-navigation" aria-controls="navbar-menu"
+        aria-expanded="true" aria-label="{{ translate('Toggle navigation') }}" aria-controls="site-navigation"
+        title="{{ translate('Toggle navigation') }}" data-toggle="tooltip" data-placement="left">
+        <i class="fas fa-bars"></i>
+        <i class="fas fa-arrow-left"></i>
+        <i class="fas fa-arrow-up"></i>
+      </button>
+      {% endif %}
+      {% include "topbar/download.html" %}
+      {% include "topbar/repobuttons.html" %}
+      {% include "topbar/fullscreen.html" %}
+      {% include "topbar/launchbuttons.html" %}
+    </div>
+
+    <!-- Table of contents -->
+    <div class="d-none d-md-block col-md-2 bd-toc show noprint">
+      {% set page_toc = generate_toc_html() %}
+
+      {%- if page_toc | length >= 1 %}
+      <div class="tocsection onthispage pt-5 pb-3">
+        <i class="fas fa-list"></i> {{ translate(theme_toc_title) }}
+      </div>
+      <nav id="bd-toc-nav" aria-label="Page">
+        {{ page_toc }}
+      </nav>
+      {%- endif %}
+    </div>
+  </div>
+</div>


### PR DESCRIPTION
As noted by @dcamron, the PyData Sphinx Theme, and therefore the Sphinx Book Theme, both contain all main content in Bootstrap `container-xl` `div` elements.  These have a `max-width` of 1400px, which results in the pages not being full-width on large screens.  Personally, I think it looks best to use `container-fluid` `div` elements, and therefore I've modified the templates accordingly.