### PR TITLE
Add feature to allow links attached to logos in footer logobar

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -163,7 +163,7 @@ html_theme_options = {
     "footer_logos": {
         "NCAR": {
             "image": "images/NCAR-contemp-logo-blue.svg",
-            "url": "https://ncar.ucar.edu"
+            "url": "https://ncar.ucar.edu",
         },
         "Unidata": {
             "image": "images/Unidata_logo_horizontal_1200x300.svg",

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -161,8 +161,13 @@ html_theme_options = {
         "standalone": "page-standalone.html",
     },
     "footer_logos": {
-        "NCAR": "images/NCAR-contemp-logo-blue.svg",
-        "Unidata": "images/Unidata_logo_horizontal_1200x300.svg",
+        "NCAR": {
+            "image": "images/NCAR-contemp-logo-blue.svg",
+            "url": "https://ncar.ucar.edu"
+        },
+        "Unidata": {
+            "image": "images/Unidata_logo_horizontal_1200x300.svg",
+        },
         "UAlbany": "images/UAlbany-A2-logo-purple-gold.svg",
     },
     "extra_navbar": ('Theme by <a href="https://projectpythia.org">Project Pythia</a>'),

--- a/sphinx_pythia_theme/__init__.py
+++ b/sphinx_pythia_theme/__init__.py
@@ -30,8 +30,18 @@ def copy_config_images(app):
         logos_config = config["footer_logos"]
 
         for key in logos_config:
-            image = logos_config[key]
-            logos_config[key] = copy_image(app, image)
+            is_dict = isinstance(logos_config[key], dict)
+
+            image = logos_config[key].get("image", "") if is_dict else logos_config[key]
+            if image:
+                image = copy_image(app, image)
+            else:
+                continue
+
+            if is_dict:
+                logos_config[key]["image"] = image
+            else:
+                logos_config[key] = image
 
 
 def add_functions_to_context(app, pagename, templatename, context, doctree):

--- a/sphinx_pythia_theme/footer-logos.html
+++ b/sphinx_pythia_theme/footer-logos.html
@@ -3,8 +3,15 @@
     <div class="container-xl">
       <div class="row d-flex flex-wrap align-items-center">
         {%- for key in theme_footer_logos %}
+        {%- set val = theme_footer_logos[key] %}
+        {%- set img = val.get('image', '') if val is mapping else val %}
+        {%- set url = val.get('url', '') if val is mapping else '' %}
         <div class="d-flex col-lg-3 col-md-4 col-sm-6 p-2 mx-auto">
-          <img alt="{{ key }}" src="{{ pathto(theme_footer_logos[key], 1) }}" style="width: 100%">
+          {%- if url %}
+          <a href="{{ pathto(url, 1) }}"><img alt="{{ key }}" src="{{ pathto(img, 1) }}" style="width: 100%"></a>
+          {%- else %}
+          <img alt="{{ key }}" src="{{ pathto(img, 1) }}" style="width: 100%">
+          {%- endif %}
         </div>
         {%- endfor %}
       </div>


### PR DESCRIPTION
This feature allows you to attach URLs to the logos in the footer logobar.  This is backward compatible, so you can now use any of these methods to set the images for the footer logobar:

```python
footer_logos: {
    'altname1': 'images/logo1.png',
    'altname2': {
        'image': 'images/logo2.png',
    },
    'altname3': {
        'image': 'images/logo3.png',
        'url': 'https://link.to/logo/site',
    },
}
```